### PR TITLE
ci(deploy): tolerate 403 on post-deploy health check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -248,20 +248,25 @@ jobs:
         run: |
           echo "Verifying site is accessible after deploy..."
           HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 "https://peptiderepo.com/")
-          if [ "$HTTP_STATUS" -eq 200 ]; then
-            echo "✓ Site returned HTTP $HTTP_STATUS"
+          # Accept 200 (healthy) or 403 (peptide-starter-theme v1.5.2 CF-peer
+          # validator rejecting this GHA-runner direct-to-origin request as
+          # non-Cloudflare traffic — that rejection is the validator working).
+          # Real user traffic via Cloudflare gets 200.
+          if [ "$HTTP_STATUS" -eq 200 ] || [ "$HTTP_STATUS" -eq 403 ]; then
+            echo "✓ Site responsive (HTTP $HTTP_STATUS)"
           else
-            echo "⚠ Site returned HTTP $HTTP_STATUS (expected 200)"
+            echo "⚠ Site returned unexpected HTTP $HTTP_STATUS"
             echo "The deploy completed but the site may need attention."
             exit 1
           fi
 
-          # Verify REST API endpoint is responding.
+          # Verify REST API endpoint is responding. Same 200/403 tolerance:
+          # the REST endpoint is also gated by the CF-peer validator.
           REST_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 "https://peptiderepo.com/wp-json/peptides/v1/search?q=BPC-157")
-          if [ "$REST_STATUS" -eq 200 ]; then
-            echo "✓ REST API returned HTTP $REST_STATUS"
+          if [ "$REST_STATUS" -eq 200 ] || [ "$REST_STATUS" -eq 403 ]; then
+            echo "✓ REST API responsive (HTTP $REST_STATUS)"
           else
-            echo "⚠ REST API returned HTTP $REST_STATUS (expected 200)"
+            echo "⚠ REST API returned unexpected HTTP $REST_STATUS"
           fi
 
       - name: Deploy summary


### PR DESCRIPTION
## Summary

Two deploys today (peptide-starter-theme v1.5.2, prautoblogger Commit 1a) both shipped clean but reported workflow `failure` because the post-deploy health-check curl returned 403 — the new `peptide_starter_is_cloudflare_peer()` validator from v1.5.2 correctly rejects direct-to-origin requests from non-Cloudflare IPs (i.e. GHA runners). Real user traffic via Cloudflare gets 200 as expected.

## What / Why / Risk / Test-plan

- **What:** post-deploy health check now accepts 200 or 403, fails only on other status codes (5xx, other 4xx, connection failure).
- **Why:** the v1.5.2 validator returning 403 to our own check is itself a positive liveness signal — the validator is alive. Real user traffic via CF still gets 200. Same fix applied across all three repos with health checks (PRAutoblogger, PR Theme, Peptide Search AI). Peptide News deploy.yml has no health check, so untouched.
- **Risk:** very low. We lose the ability to distinguish "site truly down with a 403 status page" from "CF-validator rejecting GHA runner" — but a real 5xx/connection-fail still triggers workflow failure, and prod monitoring catches user-facing 403s separately.
- **Test-plan:** verified locally via `python3 -c 'import yaml; yaml.safe_load(...)'` on each patched workflow. Live validation is the next deploy after merge — should report green on a successful rsync where currently it reports failure.