### PR TITLE
ci: add workflow_call trigger to ci.yml so deploy.yml gate resolves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request: {}
   push:
     branches: [main]
+  workflow_call: {}
 
 # Required: reusable phpcs job declares contents: write for phpcbf auto-commit,
 # but GitHub enforces that the caller must also declare it at workflow level.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the Peptide Search AI plugin will be documented in this f
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- `.github/workflows/ci.yml`: added `workflow_call: {}` trigger so `deploy.yml`'s `uses: ./.github/workflows/ci.yml` gate resolves correctly. No plugin code changed.
+
 ## [4.7.0] — 2026-06-16
 
 ### Changed


### PR DESCRIPTION
## What changed
Added `workflow_call: {}` to the `on:` block in `.github/workflows/ci.yml`. Single-line addition; no other files touched (CHANGELOG entry added for traceability).

## Why
`deploy.yml` references `uses: ./.github/workflows/ci.yml` as a pre-deploy gate job (`test:`). GitHub requires the referenced workflow to declare `workflow_call` in its `on:` block for this to resolve. Without it, every push to `main` that triggers `deploy.yml` errors immediately — the gate never runs and the deploy is blocked. This was missed when `ci.yml` was rewritten as a thin caller in v4.7.0.

## Risk flags
- No plugin code changes. No PHP, JS, or CSS touched.
- No version bump (CI-only change per CONVENTIONS).
- The `workflow_call` trigger has no inputs/outputs defined (`{}`), so callers from other workflows would need to pass none — that is exactly how `deploy.yml` calls it.

## Test plan
- CI on this PR exercises the `pull_request` trigger path (unchanged).
- The `workflow_call` path is exercised on the next merge to `main` when `deploy.yml` fires and its `test:` job resolves against this workflow.