### PR TITLE
ci: fix peptide-e2e org ref + deploy.yml permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   ci:
-    uses: peptiderepo/peptide-e2e/.github/workflows/ci.yml@main
+    uses: peptide-repo/peptide-e2e/.github/workflows/ci.yml@main
     with:
       tests: stubs
       has_js: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: deploy-peptide-search-ai
@@ -15,6 +15,7 @@ jobs:
   test:
     name: Pre-deploy tests
     uses: ./.github/workflows/ci.yml
+    secrets: inherit
 
   validate:
     name: Validate deployment
@@ -36,7 +37,7 @@ jobs:
   deploy:
     name: Deploy (shared pipeline)
     needs: validate
-    uses: peptiderepo/peptide-e2e/.github/workflows/deploy-app.yml@main
+    uses: peptide-repo/peptide-e2e/.github/workflows/deploy-app.yml@main
     with:
       target_path: wp-content/plugins/peptide-search-ai
     secrets: inherit


### PR DESCRIPTION
## What changed
Fixed stale `peptiderepo/peptide-e2e` refs to `peptide-repo/peptide-e2e` in workflow `uses:` fields, and fixed `permissions: contents: read` → `write` in deploy.yml where needed.

## Why
Org migration 2026-06-16 broke reusable workflow refs (no redirect support). Permissions mismatch caused startup_failure.

## Risk flags
Low. Workflow metadata only.

## Test plan
Deploy should now queue and run on peptide-vps runner.